### PR TITLE
Add an example of TreeDataGrid cell lifecycle events.

### DIFF
--- a/TreeDataGrid/FlatTreeDataGridSample/ViewModels/MainWindowViewModel.cs
+++ b/TreeDataGrid/FlatTreeDataGridSample/ViewModels/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Models.TreeDataGrid;
 using FlatTreeDataGridSample.Models;
@@ -50,6 +51,8 @@ internal partial class MainWindowViewModel : ViewModelBase
                 }),
             }
         };
+
+        MaxPopulation = _data.Max(x => x.Population);
     }
 
     /// <summary>
@@ -57,4 +60,9 @@ internal partial class MainWindowViewModel : ViewModelBase
     /// <see cref="Country"/> objects.
     /// </summary>
     public FlatTreeDataGridSource<Country> Source { get; }
+
+    /// <summary>
+    /// Gets the maximum population of all the countries.
+    /// </summary>
+    public int MaxPopulation { get; }
 }

--- a/TreeDataGrid/FlatTreeDataGridSample/Views/MainWindow.axaml
+++ b/TreeDataGrid/FlatTreeDataGridSample/Views/MainWindow.axaml
@@ -17,7 +17,9 @@
   <TreeDataGrid Name="countries"
                 Source="{Binding Source}"
                 AllowTriStateSorting="True"
-                AutoDragDropRows="True">
+                AutoDragDropRows="True"
+                CellPrepared="countries_CellPrepared"
+                CellClearing="countries_CellClearing">
     <TreeDataGrid.Resources>
 
       <!-- Template for Region column cells -->

--- a/TreeDataGrid/FlatTreeDataGridSample/Views/MainWindow.axaml.cs
+++ b/TreeDataGrid/FlatTreeDataGridSample/Views/MainWindow.axaml.cs
@@ -1,4 +1,8 @@
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Media;
+using FlatTreeDataGridSample.Models;
+using FlatTreeDataGridSample.ViewModels;
 
 namespace FlatTreeDataGridSample.Views;
 
@@ -7,5 +11,39 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+    }
+
+    private void countries_CellPrepared(object? sender, TreeDataGridCellEventArgs e)
+    {
+        if (GetColumnHeader(e.ColumnIndex) != "Population" ||
+            DataContext is not MainWindowViewModel viewModel ||
+            e.Cell is not TreeDataGridTextCell cell ||
+            !countries.TryGetRowModel<Country>(e.Cell, out var country))
+        {
+            return; 
+        }
+
+        // Give Population cells a blue background with an opacity value based on the percent
+        // of the maximum population they hold.
+        var opacity = (double)country.Population / viewModel.MaxPopulation;
+        
+        cell.Background = new SolidColorBrush(Colors.Blue, opacity);
+    }
+
+    private void countries_CellClearing(object? sender, TreeDataGridCellEventArgs e)
+    {
+        if (GetColumnHeader(e.ColumnIndex) != "Population" ||
+            e.Cell is not TreeDataGridTextCell cell)
+        {
+            return;
+        }
+
+        // Ensure that the population cell background is cleared when it is recycled.
+        cell.ClearValue(BackgroundProperty);
+    }
+
+    private string? GetColumnHeader(int columnIndex)
+    {
+        return countries.Columns?[columnIndex].Header as string;
     }
 }


### PR DESCRIPTION
`CellPrepared` and `CellClearing` can be used to apply custom styling to `TreeDataGrid` columns. In this case the events are used to give Population cells a blue background with an opacity value based on the percent of the maximum population they hold.